### PR TITLE
Indicate length with more ascii goodness

### DIFF
--- a/PowerAssertTests/NodeFormatterTest.cs
+++ b/PowerAssertTests/NodeFormatterTest.cs
@@ -29,6 +29,7 @@ namespace PowerAssertTests
 
             string[] expected = {
                                     "5 == 6",
+                                    "  __",
                                     "  false"
                                 };
 
@@ -54,7 +55,8 @@ namespace PowerAssertTests
 
             string[] expected = {
                                     "31 == 5 * 6",
-                                    "   |    '",
+                                    "   __   .",
+                                    "   |    .",
                                     "   |    30",
                                     "   false"
                                 };
@@ -83,8 +85,9 @@ namespace PowerAssertTests
 
             string[] expected = {
                                     "f(a, x) == 314.4",
-                                    "' '  '  |",
-                                    "| '  '  |",
+                                    ". .  .  __",
+                                    ". .  .  |",
+                                    "| .  .  |",
                                     "| |  |  False",
                                     "| |  2.423",
                                     "| 3",


### PR DESCRIPTION
Indicate the identifiers' width with more art. This makes the example look like:

```
x + 5 == d.Month * y
. .   __ . .   . . .
. .   |  . .   . . .
. |   |  . \_ _/ | .
| |   |  .   |   | |
| |   |  |   |   | 6
| |   |  |   |   18
| |   |  |   3
| |   |  1/03/2010 12:00:00 a.m.
| |   False
| 16
11
```

You may or may not think that this is a good idea.
