### PR TITLE
improved parsing of unary not wrapping binary expressions

### DIFF
--- a/PowerAssert/Infrastructure/ExpressionParser.cs
+++ b/PowerAssert/Infrastructure/ExpressionParser.cs
@@ -62,7 +62,7 @@ namespace PowerAssert.Infrastructure
                 case ExpressionType.Convert:
                     return new UnaryNode { Prefix = "(" + NameOfType(e.Type) + ")(", Operand = Parse(e.Operand), Suffix = ")", PrefixValue = GetValue(e) };
                 case ExpressionType.Not:
-                    return new UnaryNode { Prefix = "!", Operand = Parse(e.Operand), PrefixValue = GetValue(e) };
+                    return ParseUnaryNot(e);
                 case ExpressionType.Negate:
                 case ExpressionType.NegateChecked:
                     return new UnaryNode { Prefix = "-", Operand = Parse(e.Operand), PrefixValue = GetValue(e) };
@@ -71,6 +71,14 @@ namespace PowerAssert.Infrastructure
             }
             throw new ArgumentOutOfRangeException("e", string.Format("Can't handle UnaryExpression expression of class {0} and type {1}", e.GetType().Name, e.NodeType));
 
+        }
+
+        static Node ParseUnaryNot(UnaryExpression e)
+        {
+            string suffix = e.Operand is BinaryExpression ? ")" : null;
+            string prefix = e.Operand is BinaryExpression ? "!(" : "!";
+
+            return new UnaryNode { Prefix = prefix, Operand = Parse(e.Operand), PrefixValue = GetValue(e), Suffix = suffix };
         }
 
         static Node ParseExpression(NewArrayExpression e)

--- a/PowerAssertTests/ParserTest.cs
+++ b/PowerAssertTests/ParserTest.cs
@@ -194,11 +194,58 @@ namespace PowerAssertTests
             var node = ExpressionParser.Parse(f.Body);
 
             var expected = new UnaryNode
-                               {
-                                   Prefix = "!",
-                                   PrefixValue = "False",
-                                   Operand = new ConstantNode(){Text = "v", Value = "True"},
-                               };
+                                {
+                                    Prefix = "!",
+                                    PrefixValue = "False",
+                                    Operand = new ConstantNode() { Text = "v", Value = "True" },
+                                };
+
+            Assert.AreEqual(expected, node);
+        }
+
+        [Test]
+        public void ParseUnaryNotAsPartOfBinaryOperation()
+        {
+            var v = true;
+            Expression<Func<bool>> f = () => !v == false;
+            var node = ExpressionParser.Parse(f.Body);
+
+            var expected = new BinaryNode
+                            {
+                                Left = new UnaryNode
+                                        {
+                                            Prefix = "!",
+                                            PrefixValue = "False",
+                                            Operand = new ConstantNode() { Text = "v", Value = "True" },
+                                        },
+                                Right = new ConstantNode { Text = "False", Value = null },
+                                Operator = "==",
+                                Value = "True"
+                            };
+
+            Assert.AreEqual(expected, node);
+        }
+
+        [Test]
+        public void ParseUnaryNotWrappingBinaryOperation()
+        {
+            var v = true;
+            Expression<Func<bool>> f = () => !(v == false);
+            var node = ExpressionParser.Parse(f.Body);
+
+            var expected = new UnaryNode
+                            {
+                                Prefix = "!(",
+                                PrefixValue = "True",
+                                Operand = new BinaryNode
+                                            {
+                                                Left = new ConstantNode { Text = "v", Value = "True" },
+                                                Right = new ConstantNode { Text = "False", Value = null },
+                                                Operator = "==",
+                                                Value = "False"
+                                            },
+                                Suffix = ")"
+                            };
 
             Assert.AreEqual(expected, node);
         }


### PR DESCRIPTION
A unary not expression wrapping a binary expression was not parsed correctly:

`PAssert.IsTrue(() => !(one == 1))` would pretty print as `!one == 1`. This has now been addressed with a simple check on the operand type of the unary expression being parsed, resulting in a binary expression being wrapped inside parenthesis. Added two tests and verified that all earlier tests are still passing.
