### PR TITLE
[Feature request] Make enable to specify caller location

### DIFF
--- a/PowerAssert/CallerLocation.cs
+++ b/PowerAssert/CallerLocation.cs
@@ -29,6 +29,11 @@ namespace PowerAssert
             }
         }
 
+        public Type DeclaringType
+        {
+            get { return Method == null ? null : Method.DeclaringType; }
+        }
+
         public override string ToString()
         {
             if (Method == null)

--- a/PowerAssert/CallerLocation.cs
+++ b/PowerAssert/CallerLocation.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+
+namespace PowerAssert
+{
+    public class CallerLocation
+    {
+        static Assembly MyAssembly = typeof(CallerLocation).Assembly;
+
+        public string FileName { get; private set; }
+        public int LineNumber { get; private set; }
+        public MethodBase Method { get; private set; }
+
+        public CallerLocation(StackFrame f)
+        {
+            if (f == null)
+            {
+                FileName = "";
+                LineNumber = 0;
+                Method = null;
+            }
+            else
+            {
+                FileName = f.GetFileName();
+                LineNumber = f.GetFileLineNumber();
+                Method = f.GetMethod();
+            }
+        }
+
+        public override string ToString()
+        {
+            if (Method == null)
+            {
+                return "(Unknown location)";
+            }
+            var ret = string.Format("in {0}.{1}", Method.DeclaringType.Name, Method.Name);
+
+            if (!string.IsNullOrEmpty(FileName))
+            {
+                ret += string.Format(" at {0}:{1}", FileName, LineNumber);
+            }
+            return ret;
+        }
+
+        public static CallerLocation Unknown = new CallerLocation(null);
+
+        public static CallerLocation FindFromStackFrames()
+        {
+            var stackFrames = new StackTrace(1, true).GetFrames();
+            var location = (
+                    from f in stackFrames
+                    let m = f.GetMethod()
+                    where m != null && m.DeclaringType.Assembly != MyAssembly
+                    select new CallerLocation(f)
+                ).FirstOrDefault();
+
+            return location ?? CallerLocation.Unknown;
+        }
+
+        internal static CallerLocation Ensure(CallerLocation location)
+        {
+            return location ?? FindFromStackFrames();
+        }
+    }
+}

--- a/PowerAssert/Infrastructure/ExpressionParser.cs
+++ b/PowerAssert/Infrastructure/ExpressionParser.cs
@@ -33,16 +33,9 @@ namespace PowerAssert.Infrastructure
             RootExpression = expression;
             _parameters = parameters ?? new ParameterExpression[0];
             _parameterValues = parameterValues ?? new object[0];
-            TestClass = testClass ?? GetTestClass();
+            TestClass = testClass ?? CallerLocation.FindFromStackFrames().DeclaringType;
             TextOnly = textOnly;
             _nextParamIndex = baseParamIndex;
-        }
-
-        static Type GetTestClass()
-        {
-            var st = new StackTrace(1, false);
-            return st.GetFrames().Select(f => f.GetMethod().DeclaringType)
-                     .FirstOrDefault(t => t != null && t.Assembly != MyAssembly);
         }
 
         public Node Parse()

--- a/PowerAssert/MultipleAssertions/Error.cs
+++ b/PowerAssert/MultipleAssertions/Error.cs
@@ -1,44 +1,23 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
-using System.Reflection;
 
 namespace PowerAssert.MultipleAssertions
 {
     public class Error
     {
-        static Assembly MyAssembly = typeof(Error).Assembly;
-
         internal static readonly string Crlf = Environment.NewLine;
 
         static readonly string Seperator = new string('=', 60);
 
-
-        public Error(string message)
+        public Error(string message, CallerLocation location)
         {
             Message = message;
-            var stackFrames = from f in new StackTrace(1, true).GetFrames()
-                let m = f.GetMethod()
-                where m != null
-                let t = m.DeclaringType
-                where t.Assembly != MyAssembly
-                select f;
-            var frame = stackFrames.FirstOrDefault();
-            if (frame != null)
-            {
-                var method = frame.GetMethod();
-                var typeName = method.DeclaringType == null ? "" : method.DeclaringType.Name;
-                Location = string.Format("in {0}.{1} at {2}:{3}", typeName, method.Name, frame.GetFileName(), frame.GetFileLineNumber());
-            }
-            else
-            {
-                Location = "(Unknown location)";
-            }
-
+            Location = location.ToString();
         }
 
 
-        public Error(Exception exception):this(exception.Message)
+        public Error(Exception exception, CallerLocation location):this(exception.Message, location)
         {
             Exception = exception;
             CausesFail = true;

--- a/PowerAssert/MultipleAssertions/PolyAssert.cs
+++ b/PowerAssert/MultipleAssertions/PolyAssert.cs
@@ -15,33 +15,33 @@ namespace PowerAssert.MultipleAssertions
         /// <summary>
         /// Write a log message to be printed IF the PolyAssert has any errors
         /// </summary>
-        public void Log(string s)
+        public void Log(string s, CallerLocation location = null)
         {
-            _errors.Add(new Error(s));
+            _errors.Add(new Error(s, CallerLocation.Ensure(location)));
         }
 
         /// <summary>
         /// Calls PAssert.IsTrue and stores the exception, if one occurs
         /// </summary>
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public void IsTrue(Expression<Func<bool>> expression)
+        public void IsTrue(Expression<Func<bool>> expression, CallerLocation location = null)
         {
-            Try(() => PAssert.IsTrue(expression));
+            Try(() => PAssert.IsTrue(expression), CallerLocation.Ensure(location));
         }
 
         /// <summary>
         /// Calls PAssert.IsTrue and stores the exception, if one occurs
         /// </summary>
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public void IsTrue<TTarget>(TTarget target, Expression<Func<TTarget, bool>> expression)
+        public void IsTrue<TTarget>(TTarget target, Expression<Func<TTarget, bool>> expression, CallerLocation location = null)
         {
-            Try(() => PAssert.IsTrue(target, expression));
+            Try(() => PAssert.IsTrue(target, expression), CallerLocation.Ensure(location));
         }
 
         /// <summary>
         /// Runs any action and stores the exception, if one occurs
         /// </summary>
-        public void Try(Action action)
+        public void Try(Action action, CallerLocation location = null)
         {
             try
             {
@@ -49,18 +49,18 @@ namespace PowerAssert.MultipleAssertions
             }
             catch (Exception e)
             {
-                _errors.Add(new Error(e));
+                _errors.Add(new Error(e, CallerLocation.Ensure(location)));
             }
         }
 
         /// <summary>
         /// Stores a failure message, if shouldFail is true
         /// </summary>
-        public void FailIf(bool shouldFail, string message)
+        public void FailIf(bool shouldFail, string message, CallerLocation location = null)
         {
             if (shouldFail)
             {
-                _errors.Add(new Error(message) { CausesFail = true});
+                _errors.Add(new Error(message, CallerLocation.Ensure(location)) { CausesFail = true});
             }
         }
 

--- a/PowerAssert/PowerAssert.csproj
+++ b/PowerAssert/PowerAssert.csproj
@@ -92,6 +92,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Util.tt</DependentUpon>
     </Compile>
+    <Compile Include="CallerLocation.cs" />
     <Compile Include="MultipleAssertions\Error.cs" />
     <Compile Include="MultipleAssertions\PolyAssert.cs" />
     <Compile Include="MultipleAssertions\PolyAssertException.cs" />

--- a/PowerAssertTests/Approvals/EndToEndTest.ArrayIndexOfBinary.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.ArrayIndexOfBinary.approved.txt
@@ -13,5 +13,5 @@
   |  "foobar"
   102
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.ArrayLength.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.ArrayLength.approved.txt
@@ -8,5 +8,5 @@ values.Length == 1
   |      0
   []
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.BinaryArguments.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.BinaryArguments.approved.txt
@@ -12,5 +12,5 @@ String.Compare(x + "", y + "", False) == 0
           |    "foo"
           1
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.BinaryArrayElement.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.BinaryArrayElement.approved.txt
@@ -12,5 +12,5 @@ new int[]{x + 1, x + 2}[0] == 3
           | 2
           1
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.BinaryCombinationOfSamePriority.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.BinaryCombinationOfSamePriority.approved.txt
@@ -15,5 +15,5 @@
   | 1
   2
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.BrokenEqualityTestInstanceEquals.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.BrokenEqualityTestInstanceEquals.approved.txt
@@ -7,5 +7,5 @@ x.Equals(x)
 |   False, type BrokenClass has a broken equality implementation (both sides are the same object)
 PowerAssertTests.Approvals.EndToEndTest+BrokenClass
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.Casting.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.Casting.approved.txt
@@ -8,5 +8,5 @@
   |   5
   5
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.CompareDelegateAndObject.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.CompareDelegateAndObject.approved.txt
@@ -9,5 +9,5 @@ Object.Equals(f, (object)x)
          |    delegate Func<int>, type: int ()
          False, but would have been True if you had invoked 'f'
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.CompareTwoCloseFloats.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.CompareTwoCloseFloats.approved.txt
@@ -9,5 +9,5 @@ d == (double)f
 | False, but the values only differ by 1.49e-006%
 0.1
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.ComplexExpressionWithParameter.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.ComplexExpressionWithParameter.approved.txt
@@ -13,5 +13,5 @@ String.Join("", x.Select(y => y + x[0])) == new {x, Value = "foobarbaz"}.Value
         |       ["foo", "bar", "baz"]
         "foofoobarfoobazfoo"
 
-   at PowerAssert.PAssert.IsTrue[T](T target, Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue[T](T target, Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException[T](T target, Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.Enum.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.Enum.approved.txt
@@ -8,5 +8,5 @@
   |  SequentialScan
   134217728
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.EnumBackwards.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.EnumBackwards.approved.txt
@@ -8,5 +8,5 @@
       |    134217728
       False, FileOptions.Encrypted != FileOptions.SequentialScan
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.EnumerablesThatDiffer.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.EnumerablesThatDiffer.approved.txt
@@ -7,5 +7,5 @@ __       |       __
 |        False, enumerables differ at index 5, '1' != '2'
 "hello1"
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.EqualsButNotOperatorEquals.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.EqualsButNotOperatorEquals.approved.txt
@@ -7,5 +7,5 @@ __ |  __
 |  False, but would have been True with Equals()
 (foo)
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.Groupings.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.Groupings.approved.txt
@@ -7,5 +7,5 @@
 |[{"even":[0, 2, 4]}, {"odd":[1, 3]}]
 False
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.Lookups.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.Lookups.approved.txt
@@ -7,5 +7,5 @@
 |[{"even":[0, 2, 4]}, {"odd":[1, 3]}]
 False
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.MethodCallOfBinary.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.MethodCallOfBinary.approved.txt
@@ -12,5 +12,5 @@
 |1
 3
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.MethodCallOfBinaryBackward.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.MethodCallOfBinaryBackward.approved.txt
@@ -12,5 +12,5 @@
      |  3
      False, strings differ at index 0, '1' != '3'
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.NullCoalesce.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.NullCoalesce.approved.txt
@@ -10,5 +10,5 @@
 |null
 "foo"
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.NullDereference.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.NullDereference.approved.txt
@@ -11,7 +11,7 @@ null
 
  ---> System.NullReferenceException: Object reference not set to an instance of an object.
    at lambda_method(Closure )
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    --- End of inner exception stack trace ---
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.OneStringIsDecomposedVersionOfOther.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.OneStringIsDecomposedVersionOfOther.approved.txt
@@ -7,5 +7,5 @@ l == r
 | False, right string contains a decomposed character 'ö' at index 4
 "hellö"
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.OperatorPriority.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.OperatorPriority.approved.txt
@@ -16,5 +16,5 @@
 |1
 3
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.OutOfBoundsException.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.OutOfBoundsException.approved.txt
@@ -12,7 +12,7 @@ ints[150] == 49
  ---> System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection.
 Parameter name: index
    at lambda_method(Closure )
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    --- End of inner exception stack trace ---
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.PrintingComplexLinqExpressionStatements.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.PrintingComplexLinqExpressionStatements.approved.txt
@@ -14,5 +14,5 @@ list.SelectMany(x => list, (x, y) => new {x, y}).Where($0 => $0.x > $0.y).Select
  |       [{ x = 0, y = 0 }, { x = 0, y = 1 }, { x = 0, y = 2 }, { x = 0, y = 3 }, { x = 0, y = 4 }, ...]
  [0, 1, 2, 3, 4, ...]
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.PrintingDictionary.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.PrintingDictionary.approved.txt
@@ -6,5 +6,5 @@ dictionary == null
     |      False
     [{"foo":"bar"}, {"foo2":"bar2"}]
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.PrintingEnumerablesWithNulls.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.PrintingEnumerablesWithNulls.approved.txt
@@ -8,5 +8,5 @@ list.Sum() == null
  |    12
  [1, 2, null, 4, 5, ...]
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.PrintingIsTest.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.PrintingIsTest.approved.txt
@@ -6,5 +6,5 @@ b is string
 | False
 System.Object
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.PrintingLinqExpressionStatements.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.PrintingLinqExpressionStatements.approved.txt
@@ -10,5 +10,5 @@ list.Where(l => l % 2 == 0).Sum() == 0
  |     [0, 2, 4, 6, 8, ...]
  [0, 1, 2, 3, 4, ...]
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.PrintingLinqStatements.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.PrintingLinqStatements.approved.txt
@@ -10,5 +10,5 @@ list.Where(x => x % 2 == 0).Sum() == 0
  |     [0, 2, 4, 6, 8, ...]
  [0, 1, 2, 3, 4, ...]
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.PrintingMethodCall.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.PrintingMethodCall.approved.txt
@@ -12,5 +12,5 @@
 |4
 20
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.PrintingNewExpression.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.PrintingNewExpression.approved.txt
@@ -6,5 +6,5 @@ new List<string>() == null
         |          False
         []
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.PrintingTestClassFields.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.PrintingTestClassFields.approved.txt
@@ -6,5 +6,5 @@ _expected == "foo"
     |     False, strings differ at index 0, 'b' != 'f'
     "bar"
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.PrintingUnaryNegate.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.PrintingUnaryNegate.approved.txt
@@ -8,5 +8,5 @@
 |5
 -5
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.PrintingUnaryNot.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.PrintingUnaryNot.approved.txt
@@ -6,5 +6,5 @@
 |True
 False
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.PropertyAccessOfBinary.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.PropertyAccessOfBinary.approved.txt
@@ -12,5 +12,5 @@
 |"foo"
 "foo"
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.RunComplexExpression.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.RunComplexExpression.approved.txt
@@ -13,5 +13,5 @@ x + 5 == d.Month * y
 | 16
 11
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.RunComplexExpression2.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.RunComplexExpression2.approved.txt
@@ -15,5 +15,5 @@ x.Trim().Length == Math.Max(4, new int[]{5, 4, i / 3, 2}[0])
 |  "lalalaa"
 " lalalaa "
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.RunComplexExpression3.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.RunComplexExpression3.approved.txt
@@ -12,5 +12,5 @@ l[2].ToString() == (b ? "three" : "four")
 |3
 [1, 2, 3]
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.RunComplexExpressionWithStaticField.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.RunComplexExpressionWithStaticField.approved.txt
@@ -13,5 +13,5 @@ field + 5 == d.Month * y
   |   16
   11
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.RunRoundingEdgeCase.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.RunRoundingEdgeCase.approved.txt
@@ -14,5 +14,5 @@
     |  3
     False
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.RunStringCompare.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.RunStringCompare.approved.txt
@@ -9,5 +9,5 @@ s == t.Item1
 | False, but would have been True if case-insensitive
 "hello, bobby"
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.SequenceEqualButNotDotEquals.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.SequenceEqualButNotDotEquals.approved.txt
@@ -7,5 +7,5 @@ list.Equals(array)
  |     False, but would have been True with .SequenceEqual()
  [1, 2, 3]
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.SequenceEqualButNotOperatorEquals.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.SequenceEqualButNotOperatorEquals.approved.txt
@@ -7,5 +7,5 @@ list == array
  |   False, but would have been True with .SequenceEqual()
  [1, 2, 3]
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.ShouldHaveUsedTotal.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.ShouldHaveUsedTotal.approved.txt
@@ -8,5 +8,5 @@ x.Seconds == 100
 |    40
 00:01:40
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.StringContainsControlChar.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.StringContainsControlChar.approved.txt
@@ -7,5 +7,5 @@ l == r
 | False, right string contains control character 'U+0009' at index 4
 "hello"
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.StringContainsFormatChar.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.StringContainsFormatChar.approved.txt
@@ -7,5 +7,5 @@ l == r
 | False, right string contains format character 'U+200c' at index 4
 "hello"
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.StringContainsMismatchedNewlines.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.StringContainsMismatchedNewlines.approved.txt
@@ -9,5 +9,5 @@ o"
 "hell
 o"
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.StringsThatDiffer.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.StringsThatDiffer.approved.txt
@@ -7,5 +7,5 @@ __   |    __
 |    False, strings differ at index 5, '1' != '2'
 "hello1"
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.StringsThatDifferAndAreComparedCaseInsensitively.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.StringsThatDifferAndAreComparedCaseInsensitively.approved.txt
@@ -7,5 +7,5 @@ __   |    __
 |    False, strings differ at index 5, '1' != '2'
 "Hello1"
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.TestDifferingLists.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.TestDifferingLists.approved.txt
@@ -7,5 +7,5 @@ x.SequenceEqual(y)
 |       False, enumerables differ at index 5, 6 != 7
 [1, 2, 3, 4, 5, ... (6 total)]
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.TestListInitializer.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.TestListInitializer.approved.txt
@@ -7,5 +7,5 @@ new List<int>(new int[]{0}){1, 2, 3}.SequenceEqual(y)
       |                                    False, enumerables differ at index 0, 0 != 1
       [0, 1, 2, 3]
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.TestObjectInitializer.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.TestObjectInitializer.approved.txt
@@ -7,5 +7,5 @@ new UriBuilder(){Scheme = "https"} == b
        |                           False
        https://localhost/
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.UnaryCastOfBinary.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.UnaryCastOfBinary.approved.txt
@@ -11,5 +11,5 @@
   |  3.3
   3
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.UnaryNotOfBinary.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.UnaryNotOfBinary.approved.txt
@@ -9,5 +9,5 @@
 |True
 False
 
-   at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
+   at PowerAssert.PAssert.IsTrue(Expression`1 expression, CallerLocation location) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs


### PR DESCRIPTION
`PAssertExtension` was removed at d435d5d.

> My recommendation is that this class becomes a code snippet
> that anyone can add to their own test library if they want the syntactic sugar

I understand what you mean.
But when I write it in my own library, PAssert can't detect TestClass and caller location correctly.

So, I want to add optional argument  `location` to each APIs.

use case:
``` cs
public static void Should<T>(this T target, Expression<Func<T, bool>> expression)
{
    var f = new StackTrace(0, true).GetFrame(1);
    var location = new CallerLocation(f);
    PAssert.IsTrue(target, expression, location: location);
}
``` 