### PR TITLE
Support for dotnetcore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ pacakges
 *.nupkg
 *.received.txt
 *.orig
+
+.vs/
+*.lock.json

--- a/PowerAssert.Dotnet.sln
+++ b/PowerAssert.Dotnet.sln
@@ -1,0 +1,33 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{438A1BCD-7297-43BF-865D-B72B53DF64CB}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{94AAB22C-1ABA-4A93-8EED-19F690CE4586}"
+	ProjectSection(SolutionItems) = preProject
+		global.json = global.json
+		README.md = README.md
+	EndProjectSection
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "PowerAssert", "PowerAssert\PowerAssert.xproj", "{F23C9CC4-A608-44B7-8983-01AD25A2B952}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F23C9CC4-A608-44B7-8983-01AD25A2B952}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F23C9CC4-A608-44B7-8983-01AD25A2B952}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F23C9CC4-A608-44B7-8983-01AD25A2B952}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F23C9CC4-A608-44B7-8983-01AD25A2B952}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{F23C9CC4-A608-44B7-8983-01AD25A2B952} = {438A1BCD-7297-43BF-865D-B72B53DF64CB}
+	EndGlobalSection
+EndGlobal

--- a/PowerAssert/Hints/EnumComparisonShowValuesHint.cs
+++ b/PowerAssert/Hints/EnumComparisonShowValuesHint.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Linq.Expressions;
 using PowerAssert.Infrastructure;
+using System.Reflection;
 
 namespace PowerAssert.Hints
 {
@@ -57,7 +58,7 @@ namespace PowerAssert.Hints
 
             if (unE != null && unE.NodeType == ExpressionType.Convert)
             {
-                if (unE.Operand.Type.IsEnum)
+                if (unE.Operand.Type.GetTypeInfo().IsEnum)
                 {
                     return Tuple.Create(Parse(parser, unE.Operand.Type, x), Parse(parser, unE.Operand.Type, y));
                 }

--- a/PowerAssert/Hints/HintUtils.cs
+++ b/PowerAssert/Hints/HintUtils.cs
@@ -76,12 +76,12 @@ namespace PowerAssert.Hints
                 return string.Format(", right string contains control character '{0}' at index {1}", PrintableChar(rightC), index);
             }
 
-            if (char.GetUnicodeCategory(leftC) == UnicodeCategory.Format)
+            if (CharUnicodeInfo.GetUnicodeCategory(leftC) == UnicodeCategory.Format)
             {
                 return string.Format(", left string contains format character '{0}' at index {1}", PrintableChar(leftC), index);
             }
 
-            if (char.GetUnicodeCategory(rightC) == UnicodeCategory.Format)
+            if (CharUnicodeInfo.GetUnicodeCategory(rightC) == UnicodeCategory.Format)
             {
                 return string.Format(", right string contains format character '{0}' at index {1}", PrintableChar(rightC), index);
             }

--- a/PowerAssert/Hints/StringEqualsHint.cs
+++ b/PowerAssert/Hints/StringEqualsHint.cs
@@ -20,10 +20,12 @@ namespace PowerAssert.Hints
                     return StringComparer.CurrentCulture;
                 case StringComparison.CurrentCultureIgnoreCase:
                     return StringComparer.CurrentCultureIgnoreCase;
+#if !NETSTANDARD1_6
                 case StringComparison.InvariantCulture:
                     return StringComparer.InvariantCulture;
                 case StringComparison.InvariantCultureIgnoreCase:
                     return StringComparer.InvariantCultureIgnoreCase;
+#endif
                 case StringComparison.Ordinal:
                     return StringComparer.Ordinal;
                 case StringComparison.OrdinalIgnoreCase:

--- a/PowerAssert/Infrastructure/ExpressionParser.cs
+++ b/PowerAssert/Infrastructure/ExpressionParser.cs
@@ -40,9 +40,14 @@ namespace PowerAssert.Infrastructure
 
         static Type GetTestClass()
         {
+#if NETSTANDARD1_6
+			//https://github.com/dotnet/corefx/issues/1797
+			return typeof(object);
+#else
             var st = new StackTrace(1, false);
             return st.GetFrames().Select(f => f.GetMethod().DeclaringType)
                      .FirstOrDefault(t => t != null && t.Assembly != MyAssembly);
+#endif
         }
 
         public Node Parse()

--- a/PowerAssert/Infrastructure/ExpressionParser.cs
+++ b/PowerAssert/Infrastructure/ExpressionParser.cs
@@ -16,7 +16,7 @@ namespace PowerAssert.Infrastructure
 {
     class ExpressionParser
     {
-        static Assembly MyAssembly = typeof(ExpressionParser).Assembly;
+        static Assembly MyAssembly = typeof(ExpressionParser).GetTypeInfo().Assembly;
 
         public Expression RootExpression { get; private set; }
         public Type TestClass { get; private set; }
@@ -167,7 +167,7 @@ namespace PowerAssert.Infrastructure
 
         internal static string NameOfType(Type t)
         {
-            if (t.IsGenericType)
+            if (t.GetTypeInfo().IsGenericType)
             {
                 var typeArgs = t.GetGenericArguments().Select(NameOfType).ToList();
                 var name = IsAnonymousType(t) ? "$Anonymous" : t.Name.Split('`')[0];

--- a/PowerAssert/Infrastructure/Nodes/Node.cs
+++ b/PowerAssert/Infrastructure/Nodes/Node.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Linq;
+using System.Reflection;
 
 namespace PowerAssert.Infrastructure.Nodes
 {
@@ -20,7 +21,7 @@ namespace PowerAssert.Infrastructure.Nodes
                 return false;
             }
 
-            var allPropertiesMatch = from info in GetType().GetProperties()
+            var allPropertiesMatch = from info in GetType().GetTypeInfo().GetProperties()
                 let mine = info.GetValue(this, null)
                 let theirs = info.GetValue(obj, null)
                 select ObjectsOrEnumerablesEqual(mine, theirs);

--- a/PowerAssert/Infrastructure/ObjectFormatter.cs
+++ b/PowerAssert/Infrastructure/ObjectFormatter.cs
@@ -36,17 +36,17 @@ namespace PowerAssert.Infrastructure
             }
 
             var type = value.GetType();
-            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof (KeyValuePair<,>))
+            if (type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof (KeyValuePair<,>))
             {
-                var k = type.GetProperty("Key").GetValue(value, null);
-                var v = type.GetProperty("Value").GetValue(value, null);
+                var k = type.GetTypeInfo().GetProperty("Key").GetValue(value, null);
+                var v = type.GetTypeInfo().GetProperty("Value").GetValue(value, null);
                 return String.Format("{{{0}:{1}}}", FormatObject(k), FormatObject(v));
             }
-            if (type.GetInterfaces()
-                .Where(i => i.IsGenericType)
+            if (type.GetTypeInfo().GetInterfaces()
+                .Where(i => i.GetTypeInfo().IsGenericType)
                 .Any(i => i.GetGenericTypeDefinition() == typeof(IGrouping<,>)))
             {
-                var k = type.GetProperty("Key").GetValue(value, null);
+                var k = type.GetTypeInfo().GetProperty("Key").GetValue(value, null);
                 return String.Format("{{{0}:{1}}}", FormatObject(k), FormatEnumerable(value));
             }
             if (value is Type)
@@ -57,7 +57,7 @@ namespace PowerAssert.Infrastructure
             {
                 var del = (Delegate) value;
 
-                return String.Format("delegate {0}, type: {2} ({1})", ExpressionParser.NameOfType(del.GetType()), String.Join(", ", del.Method.GetParameters().Select(x => ExpressionParser.NameOfType(x.ParameterType))), ExpressionParser.NameOfType(del.Method.ReturnType));
+                return String.Format("delegate {0}, type: {2} ({1})", ExpressionParser.NameOfType(del.GetType()), String.Join(", ", del.GetMethodInfo().GetParameters().Select(x => ExpressionParser.NameOfType(x.ParameterType))), ExpressionParser.NameOfType(del.GetMethodInfo().ReturnType));
             }
             if (value is IEnumerable)
             {

--- a/PowerAssert/MultipleAssertions/Error.cs
+++ b/PowerAssert/MultipleAssertions/Error.cs
@@ -18,6 +18,10 @@ namespace PowerAssert.MultipleAssertions
         public Error(string message)
         {
             Message = message;
+#if NETSTANDARD1_6
+			//https://github.com/dotnet/corefx/issues/1797
+			Location = "<can not get location in DotNetCore>";      
+#else
             var stackFrames = from f in new StackTrace(1, true).GetFrames()
                 let m = f.GetMethod()
                 where m != null
@@ -35,7 +39,7 @@ namespace PowerAssert.MultipleAssertions
             {
                 Location = "(Unknown location)";
             }
-
+#endif
         }
 
 

--- a/PowerAssert/MultipleAssertions/Error.cs
+++ b/PowerAssert/MultipleAssertions/Error.cs
@@ -2,12 +2,13 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace PowerAssert.MultipleAssertions
 {
     public class Error
     {
-        static Assembly MyAssembly = typeof(Error).Assembly;
+        static Assembly MyAssembly = typeof(Error).GetTypeInfo().Assembly;
 
         internal static readonly string Crlf = Environment.NewLine;
 

--- a/PowerAssert/PowerAssert.csproj
+++ b/PowerAssert/PowerAssert.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PowerAssert</RootNamespace>
     <AssemblyName>PowerAssert</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/PowerAssert/PowerAssert.xproj
+++ b/PowerAssert/PowerAssert.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>f23c9cc4-a608-44b7-8983-01ad25a2b952</ProjectGuid>
+    <RootNamespace>PowerAssert</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/PowerAssert/project.json
+++ b/PowerAssert/project.json
@@ -1,0 +1,24 @@
+{
+  "title": "PowerAssert",
+  "copyright": "Copyright © Rob Fonseca-Ensor",
+  "version": "1.0.8-0",
+  "frameworks": {
+    "netstandard1.6": {
+      "imports": "dnxcore50",
+      "dependencies": {
+        "NETStandard.Library": "1.6.0",
+        "System.Diagnostics.StackTrace": "4.0.1",
+        "System.Reflection.TypeExtensions": "4.1.0",
+        "Microsoft.CSharp": "4.0.1",
+        "System.Globalization.Extensions": "4.0.1"
+      }
+    },
+    "net45": {
+      "frameworkAssemblies": {
+        "System.Core":  "",
+        "Microsoft.CSharp": "",
+        "System.Reflection": ""
+      }
+    }
+  }
+}

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+﻿{
+  "projects": [ "src", "test" ],
+  "sdk": {
+    "version": "1.0.0-preview2-003121"
+  }
+}


### PR DESCRIPTION
Dotnet core reflection uses a an extension method to be cross platform compatible, this is a simple refactor

The limitation of dotnetcore is that it currently doesn't support constructing a stack trace, this means it can't determine the calling class, which it used for context in test outputs. As a whole the functionality is still complete.


Note I have not yet tested this in a core application - just made it compile.

The test suite uses approval tests which are not yet dotnetcore compatible, this means the test suite doesn't execute against the dotnetcore version.


There are still problems with having duplicate solution files with AppVeyor, and VS gets upset with project.json *.xproj and *.csproj co existing. Pretty sure this is surmountable though.  Using [Json.Net](https://github.com/JamesNK/Newtonsoft.Json/) as a guide to getting this compiling correctly