### PR TITLE
More useful+efficient Enumerable value output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ pacakges
 *.nupkg
 *.received.txt
 *.orig
+/.vs

--- a/PowerAssert/PAssert.cs
+++ b/PowerAssert/PAssert.cs
@@ -1,11 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading.Tasks;
 using PowerAssert.Infrastructure;
 using PowerAssert.Infrastructure.Nodes;


### PR DESCRIPTION
Make the Enumerable output a little more informative, and a bit more efficient.

Specifically:
- Don't format items we won't output
- Show counts larger than 5 but less than 1001, but still only output 5.

Comments welcome.