### PR TITLE
Fixed enumerable formatting slightly and this time remembered to run…

### DIFF
--- a/PowerAssert/Infrastructure/ObjectFormatter.cs
+++ b/PowerAssert/Infrastructure/ObjectFormatter.cs
@@ -85,7 +85,7 @@ namespace PowerAssert.Infrastructure
             const int Limit = 5;
             const int LargeLimit = 1001;
 
-            var list = enumerable as IList;
+            var list = value as IList;
             var values = enumerable
                 .Take(LargeLimit)
                 .ToList();
@@ -96,20 +96,20 @@ namespace PowerAssert.Infrastructure
                     ? default(int?)
                     : values.Count;
 
+            string suffixItem = "";
             if (values.Count > Limit) {
-                var suffixItem = knownMax.HasValue
+                suffixItem = knownMax.HasValue
                     ? (knownMax.Value == LargeLimit)
-                        ? String.Format("... (at least {0})", knownMax.Value - 1)
-                        : String.Format("... ({0} total)", knownMax.Value)
-                    : "...";
+                        ? String.Format(", ... (at least {0})", knownMax.Value - 1)
+                        : String.Format(", ... ({0} total)", knownMax.Value)
+                    : ", ...";
 
                 values = values
                     .Take(Limit)
-                    .Concat(new[] {suffixItem})
                     .ToList();
             }
 
-            return "[" + String.Join(", ", values.Select(FormatObject)) + "]";
+            return "[" + String.Join(", ", values.Select(FormatObject)) + suffixItem + "]";
         }
     }
 }

--- a/PowerAssertTests/Approvals/EndToEndTest.PrintingComplexLinqExpressionStatements.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.PrintingComplexLinqExpressionStatements.approved.txt
@@ -9,10 +9,10 @@ list.SelectMany(x => list, (x, y) => new {x, y}).Where($0 => $0.x > $0.y).Select
 \ _/     |                                         |                        |                                               |     |
  |       |                                         |                        |                                               |     False
  |       |                                         |                        |                                               10
- |       |                                         |                        ["1,0", "2,0", "2,1", "3,0", "3,1", ...]
- |       |                                         [{ x = 1, y = 0 }, { x = 2, y = 0 }, { x = 2, y = 1 }, { x = 3, y = 0 }, { x = 3, y = 1 }, ...]
- |       [{ x = 0, y = 0 }, { x = 0, y = 1 }, { x = 0, y = 2 }, { x = 0, y = 3 }, { x = 0, y = 4 }, ...]
- [0, 1, 2, 3, 4, ...]
+ |       |                                         |                        ["1,0", "2,0", "2,1", "3,0", "3,1", ... (10 total)]
+ |       |                                         [{ x = 1, y = 0 }, { x = 2, y = 0 }, { x = 2, y = 1 }, { x = 3, y = 0 }, { x = 3, y = 1 }, ... (10 total)]
+ |       [{ x = 0, y = 0 }, { x = 0, y = 1 }, { x = 0, y = 2 }, { x = 0, y = 3 }, { x = 0, y = 4 }, ... (25 total)]
+ [0, 1, 2, 3, 4]
 
    at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.PrintingEnumerablesWithNulls.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.PrintingEnumerablesWithNulls.approved.txt
@@ -6,7 +6,7 @@ list.Sum() == null
 \ _/  |    |
  |    |    False
  |    12
- [1, 2, null, 4, 5, ...]
+ [1, 2, null, 4, 5]
 
    at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.PrintingLinqExpressionStatements.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.PrintingLinqExpressionStatements.approved.txt
@@ -7,8 +7,8 @@ list.Where(l => l % 2 == 0).Sum() == 0
 \ _/   |                     |    |
  |     |                     |    False
  |     |                     5550
- |     [0, 2, 4, 6, 8, ...]
- [0, 1, 2, 3, 4, ...]
+ |     [0, 2, 4, 6, 8, ... (75 total)]
+ [0, 1, 2, 3, 4, ... (150 total)]
 
    at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs

--- a/PowerAssertTests/Approvals/EndToEndTest.PrintingLinqStatements.approved.txt
+++ b/PowerAssertTests/Approvals/EndToEndTest.PrintingLinqStatements.approved.txt
@@ -7,8 +7,8 @@ list.Where(x => x % 2 == 0).Sum() == 0
 \ _/   |                     |    |
  |     |                     |    False
  |     |                     5550
- |     [0, 2, 4, 6, 8, ...]
- [0, 1, 2, 3, 4, ...]
+ |     [0, 2, 4, 6, 8, ... (75 total)]
+ [0, 1, 2, 3, 4, ... (150 total)]
 
    at PowerAssert.PAssert.IsTrue(Expression`1 expression) in ...\PAssert.cs
    at PowerAssertTests.Approvals.EndToEndTest.ApproveException(Expression`1 func) in ...\EndToEndTest.cs


### PR DESCRIPTION
…the tests and update the approval files.

The main fix is that the suffix with the `...` and maybe the count is now not treated as a string and quoted.
I also ask `value` if it's an `IList` rather than `enumerable` which never is.

Maybe next time I'm in here I'll make the `using`s that are for an `#if` block only subject to the same conditions so R# doesn't suggest removing them which would break a different build configuration..