### PR TITLE
Fixing tests after upgrade

### DIFF
--- a/PowerAssertTests/Approvals/EndToEndTest.cs
+++ b/PowerAssertTests/Approvals/EndToEndTest.cs
@@ -484,7 +484,7 @@ namespace PowerAssertTests.Approvals
                     poly.IsTrue(() => x == 5);
                     poly.IsTrue(() => x == 6);
                     poly.IsTrue(() => x == 7);
-                    poly.Try(() => Assert.Fail("Wah wah"));
+                    poly.Try(() => throw new Exception("Wah wah"));
                     poly.Log("PolyAssert.Log messages are only printed if the test fails");
                 }
             }
@@ -506,7 +506,7 @@ namespace PowerAssertTests.Approvals
                     poly.Log("Sometimes you do want to end the test early after all");
                     poly.StopIfErrorsHaveOccurred(); //no stop here
                     poly.Log("So just call StopIfErrorsHaveOccurred (behaves the same as disposing the PolyAssert)");
-                    poly.Try(() => Assert.Fail("Wah wah"));
+                    poly.Try(() => throw new Exception("Wah wah"));
                     poly.StopIfErrorsHaveOccurred(); //no stop here
                     poly.Log("This message should not be printed, as StopIfErrorsHaveOccurred will throw an exception this time");
                 }

--- a/PowerAssertTests/PowerAssertTests.csproj
+++ b/PowerAssertTests/PowerAssertTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
 	  <TargetFrameworks>net45</TargetFrameworks>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net45|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
@@ -26,10 +26,10 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-	  <PackageReference Include="ApprovalTests" Version="3.0.7" />
-      <PackageReference Include="ApprovalUtilities" Version="3.0.7" />
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-	  <PackageReference Include="nunit" Version="3.13.1" />
-	  <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="ApprovalTests" Version="3.0.7" />
+    <PackageReference Include="ApprovalUtilities" Version="3.0.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="nunit" Version="3.13.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>
 </Project>

--- a/PowerAssertTests/PowerAssertTests.csproj
+++ b/PowerAssertTests/PowerAssertTests.csproj
@@ -9,9 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <Reference Include="nunit.framework">
-		  <HintPath>..\lib\nunit.framework.dll</HintPath>
-	  </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
@@ -32,6 +29,7 @@
 	  <PackageReference Include="ApprovalTests" Version="3.0.7" />
       <PackageReference Include="ApprovalUtilities" Version="3.0.7" />
 	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+	  <PackageReference Include="nunit" Version="3.13.1" />
 	  <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>
 </Project>

--- a/PowerAssertTests/PowerAssertTests.csproj
+++ b/PowerAssertTests/PowerAssertTests.csproj
@@ -3,8 +3,15 @@
   <PropertyGroup>
 	  <TargetFrameworks>net45</TargetFrameworks>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net45|AnyCPU'">
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
 
   <ItemGroup>
+	  <Reference Include="nunit.framework">
+		  <HintPath>..\lib\nunit.framework.dll</HintPath>
+	  </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
@@ -24,8 +31,7 @@
   <ItemGroup>
 	  <PackageReference Include="ApprovalTests" Version="3.0.7" />
       <PackageReference Include="ApprovalUtilities" Version="3.0.7" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-     <PackageReference Include="nunit" Version="3.13.1" />
-     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+	  <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This fixes two problems introduced by the previous PR

1. Approvals tests was having trouble resolving namers, so have changed some build settings to help it with stack traces
2. Two unit tests were failing with the updated version of nunit. This was due to them using Assert.Fail as a way to throw an exception, without actually wanting to set the fail state of the test. This worked with older versions of NUnit but newer versions are more tricksy.